### PR TITLE
V1.5.1

### DIFF
--- a/ClusterOperator/Backlog.js
+++ b/ClusterOperator/Backlog.js
@@ -316,6 +316,32 @@ class BackLog {
   }
 
   /**
+  * [getNumberOfUpdates]
+  * @return {int}
+  */
+  static async getNumberOfUpdates(buffer = false) {
+    if (!this.BLClient) {
+      this.BLClient = await dbClient.createClient();
+      if (this.BLClient && config.dbType === 'mysql') await this.BLClient.setDB(config.dbBacklog);
+    } else {
+      try {
+        if (config.dbType === 'mysql') {
+          let records = [];
+          if (buffer) {
+            records = await this.BLClient.query(`SELECT COUNT(*) as count FROM ${config.dbBacklogBuffer} WHERE query LIKE 'update%' OR query LIKE 'set%'`);
+          } else {
+            records = await this.BLClient.query(`SELECT COUNT(*) as count FROM ${config.dbBacklogCollection} WHERE query LIKE 'update%' OR query LIKE 'set%'`);
+          }
+          if (records.length) return records[0].count;
+        }
+      } catch (e) {
+        log.error(e);
+      }
+    }
+    return 0;
+  }
+
+  /**
   * [keepConnections]
   */
   static async keepConnections() {

--- a/ClusterOperator/Backlog.js
+++ b/ClusterOperator/Backlog.js
@@ -656,6 +656,21 @@ class BackLog {
     }
   }
 
+  static async testDB() {
+    try {
+      const dbList = await this.BLClient.query(`SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '${config.dbBacklog}'`);
+      if (dbList.length === 0) {
+        log.error('DB test failed', 'red');
+        return false;
+      } else {
+        return true;
+      }
+    } catch (error) {
+      log.error('DB test failed', 'red');
+      return false;
+    }
+  }
+
   /**
   * [purgeBinLogs]
   */
@@ -674,6 +689,7 @@ class BackLog {
     }
   }
 }// end class
+
 
 // eslint-disable-next-line func-names
 module.exports = BackLog;

--- a/ClusterOperator/Backlog.js
+++ b/ClusterOperator/Backlog.js
@@ -342,6 +342,27 @@ class BackLog {
   }
 
   /**
+  * [shiftBacklogSeqNo]
+  * @return {int}
+  */
+  static async shiftBacklogSeqNo(shiftSize = 0) {
+    if (!this.BLClient) {
+      this.BLClient = await dbClient.createClient();
+      if (this.BLClient && config.dbType === 'mysql') await this.BLClient.setDB(config.dbBacklog);
+    } else {
+      try {
+        if (config.dbType === 'mysql') {
+          if (typeof shiftSize === 'number') await this.BLClient.query(`UPDATE ${config.dbBacklogCollection} set seq = seq + ${shiftSize}`);
+        }
+      } catch (e) {
+        log.error(e);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
   * [keepConnections]
   */
   static async keepConnections() {

--- a/ClusterOperator/Backlog.js
+++ b/ClusterOperator/Backlog.js
@@ -470,6 +470,7 @@ class BackLog {
       const records2 = await this.BLClient.query(`SELECT * FROM ${config.dbBacklogBuffer} ORDER BY seq`);
       if (records2.length > 0) {
         this.bufferStartSequenceNumber = records2[0].seq;
+        if (records2.length > 20) await this.moveBufferToBacklog();
       } else {
         this.bufferStartSequenceNumber = 0;
       }

--- a/ClusterOperator/Backlog.js
+++ b/ClusterOperator/Backlog.js
@@ -148,7 +148,6 @@ class BackLog {
     } catch (e) {
       this.writeLock = false;
       log.error(`error executing query, ${query}, ${seq}`);
-      log.error(e);
     }
     return [];
   }
@@ -440,7 +439,6 @@ class BackLog {
       }
     } catch (e) {
       log.error(`error executing query, ${query}, ${seq}`);
-      log.error(e);
     }
     return [];
   }

--- a/ClusterOperator/Backlog.js
+++ b/ClusterOperator/Backlog.js
@@ -744,6 +744,28 @@ class BackLog {
     }
   }
 
+  static async adjustBeaconFile(object) {
+    try {
+      fs.writeFileSync('beacon.json', JSON.stringify(object, null, 2));
+    } catch (error) {
+      console.error('Error writing to file:', error);
+    }
+  }
+
+  static async readBeaconFile() {
+    try {
+      if (fs.existsSync('beacon.json')) {
+        const fileContent = fs.readFileSync('beacon.json', 'utf8');
+        const parsedContent = JSON.parse(fileContent);
+        return parsedContent;
+      }
+      return null;
+    } catch (error) {
+      console.error('Error reading to file:', error);
+      return null;
+    }
+  }
+
   /**
   * [purgeBinLogs]
   */

--- a/ClusterOperator/Backlog.js
+++ b/ClusterOperator/Backlog.js
@@ -290,6 +290,32 @@ class BackLog {
   }
 
   /**
+  * [getFirstSequenceNumber]
+  * @return {int}
+  */
+  static async getFirstSequenceNumber(buffer = false) {
+    if (!this.BLClient) {
+      this.BLClient = await dbClient.createClient();
+      if (this.BLClient && config.dbType === 'mysql') await this.BLClient.setDB(config.dbBacklog);
+    } else {
+      try {
+        if (config.dbType === 'mysql') {
+          let records = [];
+          if (buffer) {
+            records = await this.BLClient.query(`SELECT seq as seqNo FROM ${config.dbBacklogBuffer} ORDER BY seq ASC LIMIT 1`);
+          } else {
+            records = await this.BLClient.query(`SELECT seq as seqNo FROM ${config.dbBacklogCollection} ORDER BY seq ASC LIMIT 1`);
+          }
+          if (records.length) return records[0].seqNo;
+        }
+      } catch (e) {
+        log.error(e);
+      }
+    }
+    return 0;
+  }
+
+  /**
   * [keepConnections]
   */
   static async keepConnections() {
@@ -689,7 +715,6 @@ class BackLog {
     }
   }
 }// end class
-
 
 // eslint-disable-next-line func-names
 module.exports = BackLog;

--- a/ClusterOperator/DBClient.js
+++ b/ClusterOperator/DBClient.js
@@ -219,6 +219,7 @@ exports.createClient = async function () {
   try {
     const cl = new DBClient();
     await cl.init();
+    if (!this.connected) return null;
     return cl;
   } catch (err) {
     log.info(JSON.stringify(err));

--- a/ClusterOperator/DBClient.js
+++ b/ClusterOperator/DBClient.js
@@ -98,12 +98,12 @@ class DBClient {
 
   async reconnect() {
     if (this.connected) return;
-    log.info('Attempting to reconnect to the database...');
+    // log.info('Attempting to reconnect to the database...');
     try {
       await this.init();
-      log.info('Reconnected to the database.');
+      // log.info('Reconnected to the database.');
     } catch (err) {
-      log.error(`Reconnection failed: ${err.message}`);
+      // log.error(`Reconnection failed: ${err.message}`);
       setTimeout(() => this.reconnect(), 5000); // Retry after 5 seconds
     }
   }

--- a/ClusterOperator/DBClient.js
+++ b/ClusterOperator/DBClient.js
@@ -219,7 +219,7 @@ exports.createClient = async function () {
   try {
     const cl = new DBClient();
     await cl.init();
-    if (!this.connected) return null;
+    if (!cl.connected) return null;
     return cl;
   } catch (err) {
     log.info(JSON.stringify(err));

--- a/ClusterOperator/DBClient.js
+++ b/ClusterOperator/DBClient.js
@@ -182,17 +182,21 @@ class DBClient {
   * @param {string} dbName [description]
   */
   async setDB(dbName) {
-    if (config.dbType === 'mysql') {
-      this.InitDB = dbName;
-      // log.info(`seting db to ${dbName}`);
-      this.connection.changeUser({
-        database: dbName,
-      }).catch((err) => {
-        if (err) {
-          log.error(`Error changing database: ${err}`);
-          this.reconnect();
-        }
-      });
+    try {
+      if (config.dbType === 'mysql') {
+        this.InitDB = dbName;
+        // log.info(`seting db to ${dbName}`);
+        this.connection.changeUser({
+          database: dbName,
+        }).catch((err) => {
+          if (err) {
+            log.error(`Error changing database: ${err}`);
+            this.reconnect();
+          }
+        });
+      }
+    } catch (err) {
+      log.info(err);
     }
   }
 

--- a/ClusterOperator/DBClient.js
+++ b/ClusterOperator/DBClient.js
@@ -81,7 +81,7 @@ class DBClient {
           password: Security.getKey(),
           user: config.dbUser,
           stream: this.stream,
-          connectTimeout: 60000, // Increased timeout
+          connectTimeout: 60000,
         });
         this.connection.on('error', (err) => {
           this.connected = false;
@@ -91,7 +91,7 @@ class DBClient {
         this.connected = true;
       } catch (err) {
         log.error(`Initial connection error: ${err.message}`);
-        this.reconnect();
+        setTimeout(() => this.reconnect(), 1000);
       }
     }
   }
@@ -104,7 +104,7 @@ class DBClient {
       // log.info('Reconnected to the database.');
     } catch (err) {
       // log.error(`Reconnection failed: ${err.message}`);
-      setTimeout(() => this.reconnect(), 5000); // Retry after 5 seconds
+      // setTimeout(() => this.reconnect(), 5000); // Retry after 5 seconds
     }
   }
 

--- a/ClusterOperator/DBClient.js
+++ b/ClusterOperator/DBClient.js
@@ -186,14 +186,16 @@ class DBClient {
       if (config.dbType === 'mysql') {
         this.InitDB = dbName;
         // log.info(`seting db to ${dbName}`);
-        this.connection.changeUser({
-          database: dbName,
-        }).catch((err) => {
-          if (err) {
-            log.error(`Error changing database: ${err}`);
-            this.reconnect();
-          }
-        });
+        if (this.connection) {
+          this.connection.changeUser({
+            database: dbName,
+          }).catch((err) => {
+            if (err) {
+              log.error(`Error changing database: ${err}`);
+              this.reconnect();
+            }
+          });
+        }
       }
     } catch (err) {
       log.info(err);

--- a/ClusterOperator/DBClient.js
+++ b/ClusterOperator/DBClient.js
@@ -90,6 +90,7 @@ class DBClient {
         });
         this.connected = true;
       } catch (err) {
+        this.connected = false;
         log.error(`Initial connection error: ${err.message}`);
         setTimeout(() => this.reconnect(), 1000);
       }

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -1004,12 +1004,15 @@ class Operator {
         if (this.masterCandidates[0] === this.myIP) {
           let MasterIP = this.myIP;
           // ask second candidate for confirmation
-          if (this.masterCandidates.length > 1) MasterIP = await fluxAPI.getMaster(this.masterCandidates[1], config.containerApiPort);
-          log.info(`asking second candidate for confirmation: ${MasterIP}`);
+          if (this.masterCandidates.length > 1) {
+            log.info(`asking second candidate for confirmation: ${MasterIP}`);
+            MasterIP = await fluxAPI.getMaster(this.masterCandidates[1], config.containerApiPort);
+          }
           if (MasterIP === this.myIP) {
             this.IamMaster = true;
             this.masterNode = this.myIP;
             this.status = 'OK';
+            log.info('Status OK', 'green');
           } else if (MasterIP === null || MasterIP === 'null') {
             log.info('retrying FindMaster...');
             return this.findMaster(false);
@@ -1029,6 +1032,7 @@ class Operator {
             this.IamMaster = true;
             this.masterNode = this.myIP;
             this.status = 'OK';
+            log.info('Status OK', 'green');
             BackLog.pushKey('masterIP', this.masterNode, false);
             log.info(`Master node is ${this.masterNode}`, 'yellow');
             return this.masterNode;

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -30,6 +30,8 @@ class Operator {
 
   static OpNodes = [];
 
+  static ClusterStatus = [];
+
   static masterCandidates = [];
 
   static AppNodes = [];
@@ -771,6 +773,7 @@ class Operator {
       }
       if (appIPList.length > 0) {
         this.OpNodes = [];
+        this.ClusterStatus = [];
         this.AppNodes = [];
         let checkMasterIp = false;
         const nodeList = [];
@@ -780,6 +783,7 @@ class Operator {
           nodeList.push(ipList[i].ip);
           let nodeReachable = false;
           let seqNo = 0;
+          let fullIP = ipList[i].ip;
           if (ipList[i].ip.includes(':')) {
             // eslint-disable-next-line prefer-destructuring
             ipList[i].ip = ipList[i].ip.split(':')[0];
@@ -798,6 +802,9 @@ class Operator {
           this.OpNodes.push({
             ip: ipList[i].ip, active: nodeReachable, seqNo, staticIp: ipList[i].staticIp, osUptime: ipList[i].osUptime,
           });
+          this.ClusterStatus.push({
+            ip: fullIP, active: nodeReachable, seqNo, staticIp: ipList[i].staticIp, osUptime: ipList[i].osUptime,
+          });
           if (this.masterNode && ipList[i].ip === this.masterNode) checkMasterIp = true;
         }
         if (masterConflicts > 1) {
@@ -806,7 +813,7 @@ class Operator {
           this.initMasterConnection();
           return;
         }
-        this.OpNodes.sort((a, b) => {
+        this.ClusterStatus.sort((a, b) => {
           // Priority 0: Master node
           if (a.ip === this.masterNode) {
             return -1;

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -808,8 +808,11 @@ class Operator {
         }
         this.OpNodes.sort((a, b) => {
           // Priority 0: Master node
+          if (a.ip === this.masterNode) {
+            return -1;
+          }
           if (b.ip === this.masterNode) {
-            return 1; // Master node comes first
+            return 1;
           }
           // Priority 1: Sort by seqNo in descending order
           if (a.seqNo !== b.seqNo) {

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -899,6 +899,10 @@ class Operator {
         }
         // eslint-disable-next-line no-confusing-arrow, no-nested-ternary
         this.OpNodes.sort((a, b) => {
+          // Priority 0: Master node
+          if (b.ip === this.masterNode) {
+            return 1; // Master node comes first
+          }
           // Priority 1: Sort by seqNo in descending order
           if (a.seqNo !== b.seqNo) {
             return b.seqNo - a.seqNo; // Higher seqNo comes first

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -827,7 +827,6 @@ class Operator {
       if (appIPList.length > 0) {
         this.OpNodes = [];
         const ClusterStatusTmp = [];
-        this.AppNodes = [];
         let checkMasterIp = false;
         const nodeList = [];
         let masterConflicts = 0;
@@ -893,6 +892,7 @@ class Operator {
           }
           return 0; // All priorities are equal
         });
+        this.AppNodes = [];
         this.ClusterStatus = ClusterStatusTmp;
         for (let i = 0; i < appIPList.length; i += 1) {
           // eslint-disable-next-line prefer-destructuring

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -783,7 +783,7 @@ class Operator {
           nodeList.push(ipList[i].ip);
           let nodeReachable = false;
           let seqNo = 0;
-          let fullIP = ipList[i].ip;
+          const fullIP = ipList[i].ip;
           if (ipList[i].ip.includes(':')) {
             // eslint-disable-next-line prefer-destructuring
             ipList[i].ip = ipList[i].ip.split(':')[0];
@@ -896,14 +896,14 @@ class Operator {
   /**
   * [findMaster]
   */
-  static async findMaster() {
+  static async findMaster(resetMasterCandidates = true) {
     try {
       this.status = 'INIT';
       this.masterNode = null;
       this.IamMaster = false;
       // get dbappspecs
       if (config.DBAppName) {
-        this.masterCandidates = [];
+        if (resetMasterCandidates) this.masterCandidates = [];
         await this.updateAppInfo();
         // find master candidate
         for (let i = 0; i < this.OpNodes.length; i += 1) {
@@ -932,6 +932,7 @@ class Operator {
           }
           return 0; // All priorities are equal
         });
+        this.masterCandidates = [];
         const masterSeqNo = this.OpNodes[0].seqNo;
         for (let i = 0; i < this.OpNodes.length; i += 1) {
           if (this.OpNodes[i].active && this.OpNodes[i].seqNo === masterSeqNo) {
@@ -952,7 +953,7 @@ class Operator {
             this.status = 'OK';
           } else if (MasterIP === null || MasterIP === 'null') {
             log.info('retrying FindMaster...');
-            return this.findMaster();
+            return this.findMaster(false);
           } else {
             this.masterNode = MasterIP;
           }
@@ -963,7 +964,7 @@ class Operator {
           log.info(`response was ${MasterIP}`);
           if (MasterIP === null || MasterIP === 'null') {
             log.info('retrying FindMaster...');
-            return this.findMaster();
+            return this.findMaster(false);
           }
           if (MasterIP === this.myIP) {
             this.IamMaster = true;
@@ -980,7 +981,7 @@ class Operator {
             this.masterNode = MasterIP;
           } else {
             log.info('master node not matching, retrying...');
-            return this.findMaster();
+            return this.findMaster(false);
           }
         }
         log.info(`Master node is ${this.masterNode}`, 'yellow');
@@ -991,7 +992,7 @@ class Operator {
     } catch (err) {
       log.info('error while finding master');
       log.error(err);
-      return this.findMaster();
+      return this.findMaster(false);
     }
     return null;
   }

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -773,7 +773,7 @@ class Operator {
       }
       if (appIPList.length > 0) {
         this.OpNodes = [];
-        this.ClusterStatus = [];
+        const ClusterStatusTmp = [];
         this.AppNodes = [];
         let checkMasterIp = false;
         const nodeList = [];
@@ -802,7 +802,7 @@ class Operator {
           this.OpNodes.push({
             ip: ipList[i].ip, active: nodeReachable, seqNo, staticIp: ipList[i].staticIp, osUptime: ipList[i].osUptime,
           });
-          this.ClusterStatus.push({
+          ClusterStatusTmp.push({
             ip: fullIP, active: nodeReachable, seqNo, staticIp: ipList[i].staticIp, osUptime: ipList[i].osUptime,
           });
           if (this.masterNode && ipList[i].ip === this.masterNode) checkMasterIp = true;
@@ -813,12 +813,12 @@ class Operator {
           this.initMasterConnection();
           return;
         }
-        this.ClusterStatus.sort((a, b) => {
+        ClusterStatusTmp.sort((a, b) => {
           // Priority 0: Master node
-          if (a.ip === this.masterNode) {
+          if (a.ip.split(':')[0] === this.masterNode) {
             return -1;
           }
-          if (b.ip === this.masterNode) {
+          if (b.ip.split(':')[0] === this.masterNode) {
             return 1;
           }
           // Priority 1: Sort by seqNo in descending order
@@ -839,6 +839,7 @@ class Operator {
           }
           return 0; // All priorities are equal
         });
+        this.ClusterStatus = ClusterStatusTmp;
         for (let i = 0; i < appIPList.length; i += 1) {
           // eslint-disable-next-line prefer-destructuring
           if (appIPList[i].ip.includes(':')) appIPList[i].ip = appIPList[i].ip.split(':')[0];

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -981,7 +981,7 @@ class Operator {
           // ask second candidate for confirmation
           if (this.masterCandidates.length > 1) MasterIP = await fluxAPI.getMaster(this.masterCandidates[1], config.containerApiPort);
           log.info(`asking second candidate for confirmation: ${MasterIP}`);
-          if (MasterIP === this.myIP || !this.masterCandidates.includes(MasterIP)) {
+          if (MasterIP === this.myIP) {
             this.IamMaster = true;
             this.masterNode = this.myIP;
             this.status = 'OK';

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -825,14 +825,11 @@ class Operator {
         appIPList = await fluxAPI.getApplicationIP(config.AppName);
       }
       if (appIPList.length > 0) {
-        this.OpNodes = [];
+        const OpNodesTmp = [];
         const ClusterStatusTmp = [];
         let checkMasterIp = false;
-        const nodeList = [];
         let masterConflicts = 0;
         for (let i = 0; i < ipList.length; i += 1) {
-          // extraxt ip from upnp nodes
-          nodeList.push(ipList[i].ip);
           let nodeReachable = false;
           let seqNo = 0;
           const fullIP = ipList[i].ip;
@@ -851,7 +848,7 @@ class Operator {
               if (this.masterNode && status.masterIP !== 'null' && status.masterIP !== null && status.masterIP !== this.masterNode) masterConflicts += 1;
             }
           }
-          this.OpNodes.push({
+          OpNodesTmp.push({
             ip: ipList[i].ip, active: nodeReachable, seqNo, staticIp: ipList[i].staticIp, osUptime: ipList[i].osUptime,
           });
           ClusterStatusTmp.push({
@@ -859,6 +856,9 @@ class Operator {
           });
           if (this.masterNode && ipList[i].ip === this.masterNode) checkMasterIp = true;
         }
+
+        this.OpNodes = OpNodesTmp;
+
         if (masterConflicts > 1) {
           log.info('master conflicts detected, should find a new master', 'yellow');
           this.closeMasterConnection();

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -832,6 +832,7 @@ class Operator {
         for (let i = 0; i < ipList.length; i += 1) {
           let nodeReachable = false;
           let seqNo = 0;
+          let masterIP = '';
           const fullIP = ipList[i].ip;
           if (ipList[i].ip.includes(':')) {
             // eslint-disable-next-line prefer-destructuring
@@ -840,11 +841,13 @@ class Operator {
           if (this.myIP && ipList[i].ip === this.myIP) {
             nodeReachable = true;
             seqNo = BackLog.sequenceNumber;
+            masterIP = this.masterNode;
           } else {
             const status = await fluxAPI.getStatus(ipList[i].ip, config.containerApiPort, 5000);
             if (status !== null && status !== 'null') {
               nodeReachable = true;
               seqNo = status.sequenceNumber;
+              masterIP = status.masterIP;
               if (this.masterNode && status.masterIP !== 'null' && status.masterIP !== null && status.masterIP !== this.masterNode) masterConflicts += 1;
             }
           }
@@ -852,7 +855,7 @@ class Operator {
             ip: ipList[i].ip, active: nodeReachable, seqNo, staticIp: ipList[i].staticIp, osUptime: ipList[i].osUptime,
           });
           ClusterStatusTmp.push({
-            ip: fullIP, active: nodeReachable, seqNo, staticIp: ipList[i].staticIp, osUptime: ipList[i].osUptime,
+            ip: fullIP, active: nodeReachable, seqNo, staticIp: ipList[i].staticIp, osUptime: ipList[i].osUptime, masterIP,
           });
           if (this.masterNode && ipList[i].ip === this.masterNode) checkMasterIp = true;
         }

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -677,8 +677,10 @@ class Operator {
   */
   static async updateAppInfo() {
     try {
-      const Specifications = await fluxAPI.getApplicationSpecs(config.DBAppName);
-      this.nodeInstances = Specifications.instances;
+      if (this.nodeInstances === 0) {
+        const Specifications = await fluxAPI.getApplicationSpecs(config.DBAppName);
+        this.nodeInstances = Specifications.instances;
+      }
       // wait for all nodes to spawn
       let ipList = await fluxAPI.getApplicationIP(config.DBAppName);
       const prevMaster = await BackLog.getKey('masterIP', false);
@@ -972,6 +974,7 @@ class Operator {
         }
         log.info(`working cluster ip's: ${JSON.stringify(this.OpNodes)}`);
         log.info(`masterCandidates: ${JSON.stringify(this.masterCandidates)}`);
+        await timer.setTimeout(500);
         // if first candidate is me i'm the master
         if (this.masterCandidates[0] === this.myIP) {
           let MasterIP = this.myIP;

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -1009,14 +1009,16 @@ class Operator {
             log.info(`Master node is ${this.masterNode}`, 'yellow');
             return this.masterNode;
           }
-          log.info(`asking master for confirmation @ ${MasterIP}:${config.containerApiPort}`);
-          const MasterIP2 = await fluxAPI.getMaster(MasterIP, config.containerApiPort);
-          log.info(`response from ${MasterIP} was ${MasterIP2}`);
-          if (MasterIP2 === MasterIP && this.masterCandidates.includes(MasterIP)) {
-            this.masterNode = MasterIP;
-          } else {
-            log.info('master node not matching, retrying...');
-            return this.findMaster(false);
+          if (this.masterCandidates[0] !== MasterIP) {
+            log.info(`asking master for confirmation @ ${MasterIP}:${config.containerApiPort}`);
+            const MasterIP2 = await fluxAPI.getMaster(MasterIP, config.containerApiPort);
+            log.info(`response from ${MasterIP} was ${MasterIP2}`);
+            if (MasterIP2 === MasterIP && this.masterCandidates.includes(MasterIP)) {
+              this.masterNode = MasterIP;
+            } else {
+              log.info('master node not matching, retrying...');
+              return this.findMaster(false);
+            }
           }
         }
         log.info(`Master node is ${this.masterNode}`, 'yellow');

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -1028,6 +1028,8 @@ class Operator {
               log.info('master node not matching, retrying...');
               return this.findMaster(false);
             }
+          } else {
+            this.masterNode = MasterIP;
           }
         }
         log.info(`Master node is ${this.masterNode}`, 'yellow');

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -315,7 +315,7 @@ class Operator {
         return true;
       }
       // apps only can connect to the master node
-      if (!this.operator.IamMaster && (config.AppName.includes('wordpress') || config.authMasterOnly)) return false;
+      if (!this.operator.IamMaster && (config.authMasterOnly)) return false;
       if (remoteIp === this.authorizedApp) {
         return true;
       }

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -807,6 +807,10 @@ class Operator {
           return;
         }
         this.OpNodes.sort((a, b) => {
+          // Priority 0: Master node
+          if (b.ip === this.masterNode) {
+            return 1; // Master node comes first
+          }
           // Priority 1: Sort by seqNo in descending order
           if (a.seqNo !== b.seqNo) {
             return b.seqNo - a.seqNo; // Higher seqNo comes first
@@ -899,10 +903,6 @@ class Operator {
         }
         // eslint-disable-next-line no-confusing-arrow, no-nested-ternary
         this.OpNodes.sort((a, b) => {
-          // Priority 0: Master node
-          if (b.ip === this.masterNode) {
-            return 1; // Master node comes first
-          }
           // Priority 1: Sort by seqNo in descending order
           if (a.seqNo !== b.seqNo) {
             return b.seqNo - a.seqNo; // Higher seqNo comes first

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -848,7 +848,7 @@ class Operator {
             if (status !== null && status !== 'null') {
               nodeReachable = true;
               seqNo = status.sequenceNumber;
-              if (this.masterNode && status.masterIP !== this.masterNode) masterConflicts += 1;
+              if (this.masterNode && status.masterIP !== 'null' && status.masterIP !== null && status.masterIP !== this.masterNode) masterConflicts += 1;
             }
           }
           this.OpNodes.push({

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -888,9 +888,9 @@ class Operator {
       this.IamMaster = false;
       // get dbappspecs
       if (config.DBAppName) {
+        this.masterCandidates = [];
         await this.updateAppInfo();
         // find master candidate
-        this.masterCandidates = [];
         for (let i = 0; i < this.OpNodes.length; i += 1) {
           if (this.OpNodes[i].ip === this.myIP) {
             this.OpNodes[i].active = true;

--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -39,6 +39,8 @@ class Operator {
 
   static clientNodes = [];
 
+  static appLocations = [];
+
   static nodeInstances = 0;
 
   static authorizedApp = null;
@@ -678,8 +680,15 @@ class Operator {
         const Specifications = await fluxAPI.getApplicationSpecs(config.DBAppName);
         this.nodeInstances = Specifications.instances;
       }
-      // wait for all nodes to spawn
-      let ipList = await fluxAPI.getApplicationIP(config.DBAppName);
+      // fetch cluster ip's
+      if (this.appLocations.length === 0) {
+        log.info('fetching cluster list...');
+        this.appLocations = await fluxAPI.getApplicationIP(config.DBAppName);
+        setTimeout(() => {
+          this.appLocations = [];
+        }, 2 * 60 * 1000);
+      }
+      let ipList = this.appLocations;
       const prevMaster = await BackLog.getKey('masterIP', false);
       const myip = await BackLog.getKey('myIP', false);
       if (prevMaster) {

--- a/ClusterOperator/config.js
+++ b/ClusterOperator/config.js
@@ -16,7 +16,7 @@ module.exports = {
   containerApiPort: String(process.env.API_PORT || 33950).trim(),
   DBAppName: process.env.DB_APPNAME || '',
   AppName: process.env.CLIENT_APPNAME || '',
-  version: '1.5.0',
+  version: '1.5.1',
   whiteListedIps: process.env.WHITELIST || '127.0.0.1',
   debugMode: true,
   authMasterOnly: process.env.AUTH_MASTER_ONLY || false,

--- a/ClusterOperator/server.js
+++ b/ClusterOperator/server.js
@@ -520,7 +520,7 @@ function startUI() {
 */
 async function validate(ip) {
   if (Operator.AppNodes.includes(ip)) return true;
-  log.info(`appnodes: ${JSON.stringify(Operator.AppNodes)}`);
+  // log.info(`appnodes: ${JSON.stringify(Operator.AppNodes)}`);
   return false;
   // const validateApp = await fluxAPI.validateApp(config.DBAppName, ip);
   // if (validateApp) return true;

--- a/ClusterOperator/server.js
+++ b/ClusterOperator/server.js
@@ -35,7 +35,10 @@ function auth(ip) {
   if (whiteList.length && whiteList.includes(ip)) return true;
   // only operator nodes can connect
   const idx = Operator.OpNodes.findIndex((item) => item.ip === ip);
-  if (idx === -1) return false;
+  if (idx === -1) {
+    log.info(`opnodes: ${JSON.stringify(Operator.OpNodes)}`);
+    return false;
+  }
   return true;
 }
 /**
@@ -656,7 +659,7 @@ async function initServer() {
         callback({ status: Operator.status });
       });
     } else {
-      log.warn(`rejected from ${ip}`);
+      log.warn(`rejected ${ip}`);
       socket.disconnect();
     }
     if (await validate(ip)) {

--- a/ClusterOperator/server.js
+++ b/ClusterOperator/server.js
@@ -520,6 +520,7 @@ function startUI() {
 */
 async function validate(ip) {
   if (Operator.AppNodes.includes(ip)) return true;
+  log.info(`appnodes: ${JSON.stringify(Operator.AppNodes)}`);
   return false;
   // const validateApp = await fluxAPI.validateApp(config.DBAppName, ip);
   // if (validateApp) return true;

--- a/ClusterOperator/server.js
+++ b/ClusterOperator/server.js
@@ -220,7 +220,7 @@ function startUI() {
       sequenceNumber: BackLog.sequenceNumber,
       masterIP: Operator.getMaster(),
       taskStatus: BackLog.compressionTask,
-      clusterStatus: Operator.OpNodes,
+      clusterStatus: Operator.ClusterStatus,
     });
     res.end();
   });

--- a/lib/fluxAPI.js
+++ b/lib/fluxAPI.js
@@ -151,12 +151,12 @@ async function getStatus(ip, port, timeoutTime = 1000) {
       const client = io.connect(`http://${ip}:${port}`, { transports: ['websocket', 'polling'], reconnection: false, timeout: timeoutTime });
 
       const timeout = setTimeout(() => {
-        log.info('connection timed out');
+        log.info(`connection timed out when getting status from ${ip}:${port}`);
         client.disconnect();
         resolve(null);
       }, timeoutTime);
       client.on('connect_error', (reason) => {
-        log.info('connection Error');
+        log.info(`connection Error when getting status from ${ip}:${port}`);
         log.error(reason);
         clearTimeout(timeout);
         resolve(null);

--- a/lib/fluxAPI.js
+++ b/lib/fluxAPI.js
@@ -151,7 +151,7 @@ async function getStatus(ip, port, timeoutTime = 1000) {
       const client = io.connect(`http://${ip}:${port}`, { transports: ['websocket', 'polling'], reconnection: false, timeout: timeoutTime });
 
       const timeout = setTimeout(() => {
-        log.info(`connection timed out when getting status from ${ip}:${port}`);
+        log.info(`connection timed out when getting status from ${ip}:${port}, ${timeoutTime}ms`);
         client.disconnect();
         resolve(null);
       }, timeoutTime);

--- a/lib/fluxAPI.js
+++ b/lib/fluxAPI.js
@@ -14,7 +14,7 @@ async function getApplicationSpecs(appName) {
     }
     return [];
   } catch (e) {
-    log.error(e);
+    log.error("can't reach flux api");
     return [];
   }
 }
@@ -32,7 +32,7 @@ async function getApplicationOwner(appName) {
     }
     return [];
   } catch (e) {
-    log.error(e);
+    log.error("can't reach flux api");
     return [];
   }
 }
@@ -49,7 +49,7 @@ async function getApplicationIP(appName) {
     }
     return [];
   } catch (e) {
-    log.error(e);
+    log.error("can't reach flux api");
     return [];
   }
 }
@@ -76,7 +76,7 @@ async function validateApp(appName, ip, port = 16127) {
     }
     return false;
   } catch (e) {
-    log.error(e);
+    log.error("can't reach flux api");
     return false;
   }
 }
@@ -102,7 +102,7 @@ async function getMaster(ip, port) {
       });
     });
   } catch (e) {
-    log.error(e);
+    log.error(`error socket connection to ${ip}:${port}`);
     return [];
   }
 }
@@ -134,8 +134,7 @@ async function getMyIp(ip, port) {
       });
     });
   } catch (e) {
-    log.error('socket connection failed.');
-    log.error(e);
+    log.error(`error socket connection to ${ip}:${port}`);
     return null;
   }
 }
@@ -170,8 +169,7 @@ async function getStatus(ip, port, timeoutTime = 1000) {
       });
     });
   } catch (e) {
-    log.error('socket connection failed.');
-    log.error(e);
+    log.error(`error socket connection to ${ip}:${port}`);
     return null;
   }
 }
@@ -206,8 +204,7 @@ async function resetMaster(ip, port) {
       });
     });
   } catch (e) {
-    log.error('socket connection failed.');
-    log.error(e);
+    log.error(`error socket connection to ${ip}:${port}`);
     return null;
   }
 }

--- a/lib/fluxAPI.js
+++ b/lib/fluxAPI.js
@@ -220,9 +220,12 @@ async function resetMaster(ip, port) {
  */
 async function getBackLog(index, socket) {
   try {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error('Emit timed out'));
+      }, 10000);
       socket.emit('getBackLog', index, (response) => {
-        // log.info(JSON.stringify(response));
+        clearTimeout(timer);
         resolve(response);
       });
     });
@@ -239,9 +242,13 @@ async function getBackLog(index, socket) {
  */
 async function askQuery(index, socket) {
   try {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error('Emit timed out'));
+      }, 10000);
       socket.emit('askQuery', index, (response) => {
-        log.info(JSON.stringify(response), 'magenta');
+        clearTimeout(timer);
+        // log.info(JSON.stringify(response), 'magenta');
         resolve(response);
       });
     });

--- a/ui/index.html
+++ b/ui/index.html
@@ -276,7 +276,7 @@
   <footer class="mt-3 pb-3 text-center text-light small thin">
     <span>© 2022-2023 InFlux Technologies</span>
     <span class="badge bg-dark">Beta</span>
-    <span id="build_version">v1.5.0</span>
+    <span id="build_version">v1.5.1</span>
   </footer>
 </body>
 </html>

--- a/ui/login.html
+++ b/ui/login.html
@@ -87,7 +87,7 @@
     <footer class="mt-3 pb-3 text-center small thin">
     <span>© 2022-2023 InFlux Technologies</span>
     <span class="badge bg-dark">Beta</span>
-    <span id="build_version">v1.5.0</span>
+    <span id="build_version">v1.5.1</span>
     </footer>
   </div>
   <div id="particles-js"></div>


### PR DESCRIPTION
- Improvement in primary node selection, Consensus time reduced to under ~2 seconds average.
- New Api for reporting node/cluster status.
- Set node status to 'UNINSTALL' if it has DB or other connection issues, This status will be used to inform the FluxOS to remove the app from the node.
- Caching fluxOS API calls.
- Bug fixes.