### PR TITLE
Fix: Omit buffer queries while clearing buffer

### DIFF
--- a/ClusterOperator/Operator.js
+++ b/ClusterOperator/Operator.js
@@ -780,8 +780,10 @@ class Operator {
             await timer.setTimeout(3000);
           }
           await BackLog.clearBacklog();
+          this.status = 'CLEARBUFFER';
           await BackLog.clearBuffer();
           await timer.setTimeout(200);
+          this.status = 'SYNC';
           log.info(`Importing ${beaconContent.backupFilename}, file size: ${beaconContent.BackupFilesize}`, 'cyan');
           BackLog.executeLogs = false;
           BackLog.exitOnError = true;


### PR DESCRIPTION
When operator is receiving lots of incoming queries constantly during SYNC and clearBuffer, it fails to clear the buffer, and sync process gets halted. This fixes that.